### PR TITLE
feat(backend): add optional OpenRouter translator provider

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,6 +21,13 @@ GOOGLE_CLIENT_ID=<WEB_CLIENT_ID>
 TRANSLATE_PROVIDER=gemini
 TRANSLATE_FALLBACK_PROVIDER=none
 
+# OpenRouter (set provider to openrouter to use a free model in translation flow)
+OPENROUTER_API_KEY=
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_MODEL=google/gemini-2.0-flash-exp:free
+OPENROUTER_SITE_URL=
+OPENROUTER_APP_NAME=ComicReader Backend
+
 # Local LLM (Ollama/OpenAI-compatible)
 LOCAL_LLM_BASE_URL=http://host.docker.internal:11434
 LOCAL_LLM_MODEL=qwen2.5:1.5b

--- a/backend/src/main/java/com/group09/ComicReader/config/properties/OpenRouterProperties.java
+++ b/backend/src/main/java/com/group09/ComicReader/config/properties/OpenRouterProperties.java
@@ -1,0 +1,55 @@
+package com.group09.ComicReader.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "openrouter")
+public class OpenRouterProperties {
+
+    private String apiKey = "";
+    private String baseUrl = "https://openrouter.ai/api/v1";
+    private String model = "google/gemini-2.0-flash-exp:free";
+    private String siteUrl = "";
+    private String appName = "ComicReader Backend";
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public String getSiteUrl() {
+        return siteUrl;
+    }
+
+    public void setSiteUrl(String siteUrl) {
+        this.siteUrl = siteUrl;
+    }
+
+    public String getAppName() {
+        return appName;
+    }
+
+    public void setAppName(String appName) {
+        this.appName = appName;
+    }
+}

--- a/backend/src/main/java/com/group09/ComicReader/translate/service/client/OpenRouterTranslatorClient.java
+++ b/backend/src/main/java/com/group09/ComicReader/translate/service/client/OpenRouterTranslatorClient.java
@@ -1,0 +1,159 @@
+package com.group09.ComicReader.translate.service.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group09.ComicReader.config.properties.OpenRouterProperties;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class OpenRouterTranslatorClient implements TranslatorClient {
+
+    private static final String PROVIDER_KEY = "openrouter";
+
+    private final OpenRouterProperties openRouterProperties;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public OpenRouterTranslatorClient(OpenRouterProperties openRouterProperties,
+            RestTemplate restTemplate,
+            ObjectMapper objectMapper) {
+        this.openRouterProperties = openRouterProperties;
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String getProviderKey() {
+        return PROVIDER_KEY;
+    }
+
+    @Override
+    public String getCacheIdentity() {
+        return openRouterProperties.getModel();
+    }
+
+    @Override
+    public String translate(String text, String sourceLang, String targetLang) {
+        String apiKey = normalize(openRouterProperties.getApiKey());
+        if (apiKey.isEmpty()) {
+            throw new IllegalStateException("OpenRouter API key not configured");
+        }
+
+        String model = normalize(openRouterProperties.getModel());
+        if (model.isEmpty()) {
+            throw new IllegalStateException("OpenRouter model is not configured");
+        }
+
+        String baseUrl = normalize(openRouterProperties.getBaseUrl());
+        if (baseUrl.isEmpty()) {
+            throw new IllegalStateException("OpenRouter base URL is not configured");
+        }
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+
+        String prompt = String.format(
+                "Translate the following text from %s to %s. Return ONLY the translated text, nothing else:\n\n%s",
+                "auto".equalsIgnoreCase(sourceLang) ? "the original language" : sourceLang,
+                targetLang,
+                text
+        );
+
+        Map<String, Object> requestBody = Map.of(
+                "model", model,
+                "messages", List.of(
+                        Map.of("role", "system", "content", "You are a professional translator. Return only translated text."),
+                        Map.of("role", "user", "content", prompt)
+                )
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+
+        String siteUrl = normalize(openRouterProperties.getSiteUrl());
+        if (!siteUrl.isEmpty()) {
+            headers.set("HTTP-Referer", siteUrl);
+        }
+        String appName = normalize(openRouterProperties.getAppName());
+        if (!appName.isEmpty()) {
+            headers.set("X-Title", appName);
+        }
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/chat/completions",
+                HttpMethod.POST,
+                entity,
+                String.class
+        );
+
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            throw new IllegalStateException("OpenRouter returned non-success response");
+        }
+
+        try {
+            JsonNode root = objectMapper.readTree(response.getBody());
+            JsonNode choices = root.path("choices");
+            if (choices.isArray() && !choices.isEmpty()) {
+                JsonNode contentNode = choices.get(0).path("message").path("content");
+                String translated = extractMessageContent(contentNode);
+                if (!translated.isEmpty()) {
+                    return translated;
+                }
+            }
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to parse OpenRouter response", exception);
+        }
+
+        throw new IllegalStateException("OpenRouter response contained no translation text");
+    }
+
+    private String extractMessageContent(JsonNode contentNode) {
+        if (contentNode == null || contentNode.isMissingNode() || contentNode.isNull()) {
+            return "";
+        }
+        if (contentNode.isTextual()) {
+            return contentNode.asText("").trim();
+        }
+        if (contentNode.isObject()) {
+            return contentNode.path("text").asText("").trim();
+        }
+        if (contentNode.isArray()) {
+            StringBuilder builder = new StringBuilder();
+            for (JsonNode item : contentNode) {
+                if (item == null || item.isNull()) {
+                    continue;
+                }
+                String part;
+                if (item.isTextual()) {
+                    part = item.asText("").trim();
+                } else {
+                    part = item.path("text").asText("").trim();
+                }
+                if (part.isEmpty()) {
+                    continue;
+                }
+                if (builder.length() > 0) {
+                    builder.append('\n');
+                }
+                builder.append(part);
+            }
+            return builder.toString().trim();
+        }
+        return "";
+    }
+
+    private String normalize(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -36,6 +36,13 @@ app:
 gemini:
     api-key: ${GEMINI_API_KEY:}
 
+openrouter:
+    api-key: ${OPENROUTER_API_KEY:}
+    base-url: ${OPENROUTER_BASE_URL:https://openrouter.ai/api/v1}
+    model: ${OPENROUTER_MODEL:google/gemini-2.0-flash-exp:free}
+    site-url: ${OPENROUTER_SITE_URL:}
+    app-name: ${OPENROUTER_APP_NAME:ComicReader Backend}
+
 translate:
     provider: ${TRANSLATE_PROVIDER:gemini}
     fallback-provider: ${TRANSLATE_FALLBACK_PROVIDER:none}

--- a/backend/src/test/java/com/group09/ComicReader/translate/service/TranslateServiceTest.java
+++ b/backend/src/test/java/com/group09/ComicReader/translate/service/TranslateServiceTest.java
@@ -23,6 +23,7 @@ class TranslateServiceTest {
     private TranslateProperties translateProperties;
     private FakeTranslatorClient localClient;
     private FakeTranslatorClient geminiClient;
+    private FakeTranslatorClient openrouterClient;
     private TranslateService translateService;
 
     @BeforeEach
@@ -33,7 +34,12 @@ class TranslateServiceTest {
 
         localClient = new FakeTranslatorClient("local", "qwen2.5:1.5b");
         geminiClient = new FakeTranslatorClient("gemini", "gemini-2.5-flash");
-        translateService = new TranslateService(comicService, translateProperties, List.of(localClient, geminiClient));
+        openrouterClient = new FakeTranslatorClient("openrouter", "google/gemini-2.0-flash-exp:free");
+        translateService = new TranslateService(
+                comicService,
+                translateProperties,
+                List.of(localClient, geminiClient, openrouterClient)
+        );
     }
 
     @Test
@@ -45,6 +51,7 @@ class TranslateServiceTest {
         assertThat(translated).isEqualTo("xin chao");
         assertThat(localClient.getCallCount()).isEqualTo(1);
         assertThat(geminiClient.getCallCount()).isZero();
+        assertThat(openrouterClient.getCallCount()).isZero();
     }
 
     @Test
@@ -58,6 +65,7 @@ class TranslateServiceTest {
         assertThat(translated).isEqualTo("xin chao tu gemini");
         assertThat(localClient.getCallCount()).isEqualTo(1);
         assertThat(geminiClient.getCallCount()).isEqualTo(1);
+        assertThat(openrouterClient.getCallCount()).isZero();
     }
 
     @Test
@@ -84,6 +92,20 @@ class TranslateServiceTest {
 
         String second = translateService.translate("hello", "en", "vi").getTranslatedText();
         assertThat(second).isEqualTo("result-gemini");
+    }
+
+    @Test
+    void shouldSupportOpenRouterProvider() {
+        translateProperties.setProvider("openrouter");
+        translateProperties.setFallbackProvider("none");
+        openrouterClient.setResult("xin chao tu openrouter");
+
+        String translated = translateService.translate("hello", "en", "vi").getTranslatedText();
+
+        assertThat(translated).isEqualTo("xin chao tu openrouter");
+        assertThat(openrouterClient.getCallCount()).isEqualTo(1);
+        assertThat(localClient.getCallCount()).isZero();
+        assertThat(geminiClient.getCallCount()).isZero();
     }
 
     private static class FakeTranslatorClient implements TranslatorClient {


### PR DESCRIPTION
## Summary
- Add optional `openrouter` translator client for translation flow.
- Add `openrouter.*` configuration properties and `.env.example` entries.
- Keep default provider as Gemini (`translate.provider=gemini`); OpenRouter is used only when explicitly set to `openrouter`.
- Extend `TranslateServiceTest` to cover OpenRouter provider path.

## Test Plan
- [x] `cd backend && .\\mvnw.cmd -Dtest=TranslateServiceTest test`
- [ ] Optional: run full backend suite `cd backend && .\\mvnw.cmd test`